### PR TITLE
Refactor to allow loading of current IMEDS vocabulary data

### DIFF
--- a/lib/loadmop/vocab_loader.rb
+++ b/lib/loadmop/vocab_loader.rb
@@ -14,50 +14,44 @@ module Loadmop
       relationship_table = table_name(:relationship)
 
       create_schema_if_necessary
-      db.create_table!(table_name(:vocabulary)) do
-        Bignum :vocabulary_id, :null=>false
+      db.create_table?(table_name(:vocabulary)) do
+        Bignum :vocabulary_id, :primary_key=>true
         String :vocabulary_name, :null=>false
-
-        primary_key [:vocabulary_id]
       end
 
-      db.create_table!(table_name(:relationship)) do
-        Bignum :relationship_id, :null=>false
+      db.create_table?(table_name(:relationship)) do
+        Bignum :relationship_id, :primary_key=>true
         String :relationship_name, :null=>false
         String :is_hierarchical, :size=>1, :fixed=>true
         String :defines_ancestry, :size=>1, :fixed=>true
-        foreign_key :reverse_relationship, relationship_table, type: Bignum, key: :relationship_id
-
-        primary_key [:relationship_id]
+        foreign_key :reverse_relationship, relationship_table, type: Bignum
       end
 
-      db.create_table!(table_name(:concept)) do
-        Bignum :concept_id, :null=>false
+      db.create_table?(table_name(:concept)) do
+        Bignum :concept_id, :primary_key=>true
         String :concept_name, :null=>false
         BigDecimal :concept_level, :null=>false
         String :concept_class, :null=>false
-        foreign_key :vocabulary_id, vocabulary_table, :null=>false, type: Bignum, key: [:vocabulary_id]
+        foreign_key :vocabulary_id, vocabulary_table, :null=>false, type: Bignum
         String :concept_code, :null=>false
         Date :valid_start_date, :null=>false
         Date :valid_end_date, :null=>false
         String :invalid_reason, :size=>1, :fixed=>true
-
-        primary_key [:concept_id]
       end
 
-      db.create_table!(table_name(:concept_ancestor)) do
-        foreign_key :ancestor_concept_id, concept_table, :null=>false, type: Bignum, key: [:concept_id]
-        foreign_key :descendant_concept_id, concept_table, :null=>false, type: Bignum, key: [:concept_id]
+      db.create_table?(table_name(:concept_ancestor)) do
+        foreign_key :ancestor_concept_id, concept_table, :null=>false, type: Bignum
+        foreign_key :descendant_concept_id, concept_table, :null=>false, type: Bignum
         BigDecimal :min_levels_of_separation
         BigDecimal :max_levels_of_separation
 
         primary_key [:ancestor_concept_id, :descendant_concept_id]
       end
 
-      db.create_table!(table_name(:concept_relationship)) do
-        foreign_key :concept_id_1, concept_table, :null=>false, type: Bignum, key: [:concept_id]
-        foreign_key :concept_id_2, concept_table, :null=>false, type: Bignum, key: [:concept_id]
-        foreign_key :relationship_id, relationship_table, :null=>false, type: Bignum, key: [:relationship_id]
+      db.create_table?(table_name(:concept_relationship)) do
+        foreign_key :concept_id_1, concept_table, :null=>false, type: Bignum
+        foreign_key :concept_id_2, concept_table, :null=>false, type: Bignum
+        foreign_key :relationship_id, relationship_table, :null=>false, type: Bignum
         Date :valid_start_date, :null=>false
         Date :valid_end_date, :null=>false
         String :invalid_reason, :size=>1, :fixed=>true
@@ -65,21 +59,19 @@ module Loadmop
         primary_key [:concept_id_1, :concept_id_2, :relationship_id]
       end
 
-      db.create_table!(table_name(:concept_synonym)) do
-        Bignum :concept_synonym_id, :null=>false
-        foreign_key :concept_id, concept_table, :null=>false, type: Bignum, key: [:concept_id]
+      db.create_table?(table_name(:concept_synonym)) do
+        Bignum :concept_synonym_id, :primary_key=>true
+        foreign_key :concept_id, concept_table, :null=>false, type: Bignum
         String :concept_synonym_name, :null=>false
-
-        primary_key [:concept_synonym_id]
       end
 
-      db.create_table!(table_name(:drug_approval)) do
+      db.create_table?(table_name(:drug_approval)) do
         Bignum :ingredient_concept_id, :null => false
         Date :approval_date, :null => false
         String :approved_by, :null => false
       end
 
-      db.create_table!(table_name(:drug_strength)) do
+      db.create_table?(table_name(:drug_strength)) do
         Bignum :drug_concept_id, :null => false
         Bignum :ingredient_concept_id, :null => false
         BigDecimal :amount_value
@@ -92,12 +84,12 @@ module Loadmop
         String :invalid_reason
       end
 
-      db.create_table!(table_name(:source_to_concept_map)) do
+      db.create_table?(table_name(:source_to_concept_map)) do
         String :source_code, :null=>false
-        foreign_key :source_vocabulary_id, vocabulary_table, :null=>false, type: Bignum, key: [:vocabulary_id]
+        foreign_key :source_vocabulary_id, vocabulary_table, :null=>false, type: Bignum
         String :source_code_description
-        foreign_key :target_concept_id, concept_table, :null=>false, type: Bignum, key: [:concept_id]
-        foreign_key :target_vocabulary_id, vocabulary_table, :null=>false, type: Bignum, key: [:vocabulary_id]
+        foreign_key :target_concept_id, concept_table, :null=>false, type: Bignum
+        foreign_key :target_vocabulary_id, vocabulary_table, :null=>false, type: Bignum
         String :mapping_type
         String :primary_map, :size=>1, :fixed=>true
         Date :valid_start_date, :null=>false


### PR DESCRIPTION
There are a lot of interrelated changes here.  The reason behind
them is the IMEDS data format changed significantly, which made
the vocabulary data diverage in format from the cdm data, so
refactoring and adding some methods to the Loader subclasses
was necessary so that the same Loader superclass would work with
both.

Drop the headers hash, instead storing the headers in the all_files
data structure.  Change all_files from being a hash to being an
array, since it doesn't seem to be used as a hash.

In fast load, use symbols instead of strings, as apprantly adapter
is now a symbol.

Add postgres_copy_into_options and ruby_csv_options methods, which
the vocab loader overrides to deal with the nonstandard format
IMEDS uses for the vocabulary data.

Set the binary flag when reading files, to avoid encoding errors,
as the IMEDS data does not use UTF-8 format.

Use Sequel.qualify instead of constructing double underscored
symbols at runtime.

Set ASCII 242 as the field separator, and ASCII 255 as the quote
character.  The IMEDS data doesn't use a quote character, but
includes the quote character as a data character.  Filter out
carriage returns from the IMEDS data before splitting it, as both
PostgreSQL and ruby's CSV library don't allow carriage returns
in unquoted fields.

This also includes a commit to fix issues in creating the tables
after foreign key support was added.
