### PR TITLE
Foreign key changes for cdmv4 loader

### DIFF
--- a/lib/loadmop/cdmv4_loader.rb
+++ b/lib/loadmop/cdmv4_loader.rb
@@ -42,30 +42,26 @@ module Loadmop
       person_table = table_name(:person)
       drug_exposure_table = table_name(:drug_exposure)
       procedure_occurrence_table = table_name(:procedure_occurrence)
-      db.create_table!(table_name(:care_site), :ignore_index_errors=>true) do
-        Bignum :care_site_id, :null=>false
+      db.create_table?(table_name(:care_site), :ignore_index_errors=>true) do
+        Bignum :care_site_id, :primary_key=>true
         Bignum :location_id, :null=>false
         Bignum :organization_id, :null=>false
         Bignum :place_of_service_concept_id
         String :care_site_source_value, :size=>50
         String :place_of_service_source_value, :size=>50, :null=>false
-
-        primary_key [:care_site_id]
       end
 
-      db.create_table!(table_name(:cohort), :ignore_index_errors=>true) do
-        Bignum :cohort_id, :null=>false
+      db.create_table?(table_name(:cohort), :ignore_index_errors=>true) do
+        Bignum :cohort_id, :primary_key=>true
         Bignum :cohort_concept_id, :null=>false
         Date :cohort_start_date, :null=>false
         Date :cohort_end_date
         Bignum :subject_id, :null=>false
         String :stop_reason, :size=>20
-
-        primary_key [:cohort_id]
       end
 
-      db.create_table!(table_name(:location), :ignore_index_errors=>true) do
-        Bignum :location_id, :null=>false
+      db.create_table?(table_name(:location), :ignore_index_errors=>true) do
+        Bignum :location_id, :primary_key=>true
         String :address_1, :size=>50
         String :address_2, :size=>50
         String :city, :size=>50
@@ -73,66 +69,56 @@ module Loadmop
         String :zip, :size=>9
         String :county, :size=>20
         String :location_source_value, :size=>50
-
-        primary_key [:location_id]
       end
 
-      db.create_table!(table_name(:provider), :ignore_index_errors=>true) do
-        Bignum :provider_id, :null=>false
+      db.create_table?(table_name(:provider), :ignore_index_errors=>true) do
+        Bignum :provider_id, :primary_key=>true
         String :npi, :size=>20
         String :dea, :size=>20
         Bignum :specialty_concept_id
         Bignum :care_site_id, :null=>false
         String :provider_source_value, :size=>50, :null=>false
         String :specialty_source_value, :size=>50
-
-        primary_key [:provider_id]
       end
 
-      db.create_table!(table_name(:organization), :ignore_index_errors=>true) do
-        Bignum :organization_id, :null=>false
+      db.create_table?(table_name(:organization), :ignore_index_errors=>true) do
+        Bignum :organization_id, :primary_key=>true
         Bignum :place_of_service_concept_id
-        foreign_key :location_id, location_table, :type=>Bignum, :key=>[:location_id]
+        foreign_key :location_id, location_table, :type=>Bignum
         String :organization_source_value, :size=>50, :null=>false
         String :place_of_service_source_value, :size=>50
-
-        primary_key [:organization_id]
       end
 
-      db.create_table!(table_name(:person), :ignore_index_errors=>true) do
-        Bignum :person_id, :null=>false
+      db.create_table?(table_name(:person), :ignore_index_errors=>true) do
+        Bignum :person_id, :primary_key=>true
         Bignum :gender_concept_id, :null=>false
         Integer :year_of_birth, :null=>false
         Integer :month_of_birth
         Integer :day_of_birth
         Bignum :race_concept_id
         Bignum :ethnicity_concept_id
-        foreign_key :location_id, location_table, :type=>Bignum, :key=>[:location_id]
-        foreign_key :provider_id, provider_table, :type=>Bignum, :key=>[:provider_id]
+        foreign_key :location_id, location_table, :type=>Bignum
+        foreign_key :provider_id, provider_table, :type=>Bignum
         Bignum :care_site_id
         String :person_source_value, :size=>50
         String :gender_source_value, :size=>50
         String :race_source_value, :size=>50
         String :ethnicity_source_value, :size=>50
-
-        primary_key [:person_id]
       end
 
-      db.create_table!(table_name(:condition_era), :ignore_index_errors=>true) do
-        Bignum :condition_era_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:condition_era), :ignore_index_errors=>true) do
+        Bignum :condition_era_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :condition_concept_id, :null=>false
         Date :condition_era_start_date, :null=>false
         Date :condition_era_end_date, :null=>false
         Bignum :condition_type_concept_id, :null=>false
         Integer :condition_occurrence_count
-
-        primary_key [:condition_era_id]
       end
 
-      db.create_table!(table_name(:condition_occurrence), :ignore_index_errors=>true) do
-        Bignum :condition_occurrence_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:condition_occurrence), :ignore_index_errors=>true) do
+        Bignum :condition_occurrence_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :condition_concept_id, :null=>false
         Date :condition_start_date, :null=>false
         Date :condition_end_date
@@ -141,35 +127,29 @@ module Loadmop
         Bignum :associated_provider_id
         Bignum :visit_occurrence_id
         String :condition_source_value, :size=>50
-
-        primary_key [:condition_occurrence_id]
       end
 
-      db.create_table!(table_name(:death), :ignore_index_errors=>true) do
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:death), :ignore_index_errors=>true) do
+        foreign_key :person_id, person_table, :type=>Bignum, :primary_key=>true
         Date :death_date, :null=>false
         Bignum :death_type_concept_id, :null=>false
         Bignum :cause_of_death_concept_id
         String :cause_of_death_source_value, :size=>50
-
-        primary_key [:person_id]
       end
 
-      db.create_table!(table_name(:drug_era), :ignore_index_errors=>true) do
-        Bignum :drug_era_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:drug_era), :ignore_index_errors=>true) do
+        Bignum :drug_era_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :drug_concept_id, :null=>false
         Date :drug_era_start_date, :null=>false
         Date :drug_era_end_date, :null=>false
         Bignum :drug_type_concept_id, :null=>false
         Integer :drug_exposure_count
-
-        primary_key [:drug_era_id]
       end
 
-      db.create_table!(table_name(:drug_exposure), :ignore_index_errors=>true) do
-        Bignum :drug_exposure_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:drug_exposure), :ignore_index_errors=>true) do
+        Bignum :drug_exposure_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :drug_concept_id, :null=>false
         Date :drug_exposure_start_date, :null=>false
         Date :drug_exposure_end_date
@@ -183,13 +163,11 @@ module Loadmop
         Bignum :visit_occurrence_id
         Bignum :relevant_condition_concept_id
         String :drug_source_value, :size=>50
-
-        primary_key [:drug_exposure_id]
       end
 
-      db.create_table!(table_name(:observation), :ignore_index_errors=>true) do
-        Bignum :observation_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:observation), :ignore_index_errors=>true) do
+        Bignum :observation_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :observation_concept_id, :null=>false
         Date :observation_date, :null=>false
         Date :observation_time
@@ -205,36 +183,30 @@ module Loadmop
         Bignum :relevant_condition_concept_id
         String :observation_source_value, :size=>50
         String :units_source_value, :size=>50
-
-        primary_key [:observation_id]
       end
 
-      db.create_table!(table_name(:observation_period), :ignore_index_errors=>true) do
-        Bignum :observation_period_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:observation_period), :ignore_index_errors=>true) do
+        Bignum :observation_period_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Date :observation_period_start_date, :null=>false
         Date :observation_period_end_date, :null=>false
         Date :prev_ds_period_end_date
-
-        primary_key [:observation_period_id]
       end
 
-      db.create_table!(table_name(:payer_plan_period), :ignore_index_errors=>true) do
-        Bignum :payer_plan_period_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:payer_plan_period), :ignore_index_errors=>true) do
+        Bignum :payer_plan_period_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Date :payer_plan_period_start_date, :null=>false
         Date :payer_plan_period_end_date, :null=>false
         String :payer_source_value, :size=>50
         String :plan_source_value, :size=>50
         String :family_source_value, :size=>50
         Date :prev_ds_period_end_date
-
-        primary_key [:payer_plan_period_id]
       end
 
-      db.create_table!(table_name(:procedure_occurrence), :ignore_index_errors=>true) do
-        Bignum :procedure_occurrence_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:procedure_occurrence), :ignore_index_errors=>true) do
+        Bignum :procedure_occurrence_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Bignum :procedure_concept_id, :null=>false
         Date :procedure_date, :null=>false
         Bignum :procedure_type_concept_id, :null=>false
@@ -242,25 +214,21 @@ module Loadmop
         Bignum :visit_occurrence_id
         Bignum :relevant_condition_concept_id
         String :procedure_source_value, :size=>50
-
-        primary_key [:procedure_occurrence_id]
       end
 
-      db.create_table!(table_name(:visit_occurrence), :ignore_index_errors=>true) do
-        Bignum :visit_occurrence_id, :null=>false
-        foreign_key :person_id, person_table, :type=>Bignum, :null=>false, :key=>[:person_id]
+      db.create_table?(table_name(:visit_occurrence), :ignore_index_errors=>true) do
+        Bignum :visit_occurrence_id, :primary_key=>true
+        foreign_key :person_id, person_table, :type=>Bignum, :null=>false
         Date :visit_start_date, :null=>false
         Date :visit_end_date, :null=>false
         Bignum :place_of_service_concept_id, :null=>false
         Bignum :care_site_id
         String :place_of_service_source_value, :size=>50
-
-        primary_key [:visit_occurrence_id]
       end
 
-      db.create_table!(table_name(:drug_cost), :ignore_index_errors=>true) do
-        Bignum :drug_cost_id, :null=>false
-        foreign_key :drug_exposure_id, drug_exposure_table, :type=>Bignum, :null=>false, :key=>[:drug_exposure_id]
+      db.create_table?(table_name(:drug_cost), :ignore_index_errors=>true) do
+        Bignum :drug_cost_id, :primary_key=>true
+        foreign_key :drug_exposure_id, drug_exposure_table, :type=>Bignum, :null=>false
         Float :paid_copay
         Float :paid_coinsurance
         Float :paid_toward_deductible
@@ -272,13 +240,11 @@ module Loadmop
         Float :dispensing_fee
         Float :average_wholesale_price
         Bignum :payer_plan_period_id
-
-        primary_key [:drug_cost_id]
       end
 
-      db.create_table!(table_name(:procedure_cost), :ignore_index_errors=>true) do
-        Bignum :procedure_cost_id, :null=>false
-        foreign_key :procedure_occurrence_id, procedure_occurrence_table, :type=>Bignum, :null=>false, :key=>[:procedure_occurrence_id]
+      db.create_table?(table_name(:procedure_cost), :ignore_index_errors=>true) do
+        Bignum :procedure_cost_id, :primary_key=>true
+        foreign_key :procedure_occurrence_id, procedure_occurrence_table, :type=>Bignum, :null=>false
         Float :paid_copay
         Float :paid_coinsurance
         Float :paid_toward_deductible
@@ -291,8 +257,6 @@ module Loadmop
         Bignum :payer_plan_period_id
         String :disease_class_source_value, :size=>50
         String :revenue_code_source_value, :size=>50
-
-        primary_key [:procedure_cost_id]
       end
     end
 


### PR DESCRIPTION
Similar to the vocab loader, use create_table? instead of create_table!,
remove unnecessary :key, and use :primary_key column option.

After making these changes, I decided to copy this code into conceptql's
test framework and modify it, so this won't be necessary for conceptql
testing, but it's best to be consistent.
