### PR TITLE
Get manual running of jobs back

### DIFF
--- a/.github/workflows/gdm.yml
+++ b/.github/workflows/gdm.yml
@@ -1,6 +1,8 @@
 ---
 name: Build GDM DBs
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 jobs:
   Run-Tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This should reinstate the missing Run Job button from GitHub Actions